### PR TITLE
Improve layout and color scheme

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,19 +1,22 @@
 /* ========== 基本設定 ========== */
 body {
-  font-family: sans-serif;
-  background-color: #e0e0e0;
+  font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  background: linear-gradient(to bottom, #fafafa 0%, #ffe6f2 100%);
   margin: 0;
-  padding: 20px;
+  padding: 0;
+  max-width: 960px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 h1 {
   text-align: center;
-  background-color: #f8b8c9;
-  color: white;
-  padding: 15px 0;
-  margin-bottom: 0;
-  border-radius: 12px 12px 0 0;
-  font-size: 36px;
+  background: linear-gradient(90deg, #ff9a9e, #fad0c4);
+  color: #333;
+  padding: 20px 0;
+  margin: 0;
+  font-size: 40px;
+  letter-spacing: 2px;
 }
 
 h2 {
@@ -43,29 +46,28 @@ img {
 
 /* ========== タイトル下サブヘッダー ========== */
 .sub-header {
-  background-color: #f8b8c9;
+  background-color: #ffe6f2;
   text-align: center;
-  padding: 5px 0 15px;
-  border-radius: 0 0 12px 12px;
-  margin-bottom: 20px;
+  padding: 10px 0 20px;
+  margin-bottom: 30px;
 }
 
 .sub-header hr {
-  width: 50%;
+  width: 40%;
   border: none;
-  border-top: 1px solid white;
-  margin: 8px auto;
+  border-top: 1px solid #ff9a9e;
+  margin: 10px auto;
 }
 
 .sub-header p {
-  color: white;
+  color: #333;
   margin: 0;
-  font-size: 14px;
+  font-size: 15px;
 }
 
 /* ========== ナビゲーション ========== */
 .nav {
-  background-color: #fff0f5;
+  background-color: #333;
   position: sticky;
   top: 0;
   z-index: 999;
@@ -96,15 +98,15 @@ img {
   display: block;
   padding: 14px 16px;
   text-decoration: none;
-  color: #2196f3;
+  color: #fff;
   font-weight: bold;
   transition: background-color 0.2s;
 }
 
 .nav-list > li > a:hover,
 .nav-list > li > a.active {
-  background-color: #f8b8c9;
-  color: white;
+  background-color: #555;
+  color: #fff;
 }
 
 /* ▼ ドロップダウンメニュー */
@@ -112,7 +114,7 @@ img {
   list-style: none;
   padding: 0;
   margin: 0;
-  background-color: white;
+  background-color: #444;
   min-width: 140px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.15);
   border-radius: 4px;
@@ -126,12 +128,12 @@ img {
   display: block;
   padding: 10px 14px;
   text-decoration: none;
-  color: #2196f3;
+  color: #fff;
   font-weight: normal;
 }
 
 .dropdown-menu li a:hover {
-  background-color: #f0f8ff;
+  background-color: #666;
 }
 
 .dropdown:hover .dropdown-menu {
@@ -141,13 +143,16 @@ img {
 /* ========== セクション全体設定 ========== */
 section {
   margin-bottom: 40px;
-  padding: 10px;
+  padding: 20px;
+  background-color: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 /* ========== ギャラリー・画像レイアウト ========== */
 .gallery {
   display: flex;
-  gap: 30px;
+  gap: 40px;
   justify-content: center;
   margin-bottom: 40px;
 }
@@ -156,19 +161,22 @@ section {
   display: flex;
   flex-wrap: nowrap;
   justify-content: space-between;
-  gap: 10px;
+  gap: 20px;
 }
 
 .gallery-card .card {
   width: 23.5%;
   padding: 0;
-  background: none;
-  box-shadow: none;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  border-radius: 6px;
+  overflow: hidden;
 }
 
 .gallery-card .card img {
   width: 100%;
-  margin-bottom: 5px;
+  display: block;
+  margin-bottom: 0;
 }
 
 .gallery-card .card p {
@@ -222,8 +230,8 @@ section {
 .country-list li {
   margin-bottom: 10px;
   padding: 10px;
-  background-color: #fff8fb;
-  border-left: 4px solid #f8b8c9;
+  background-color: #f7f7f7;
+  border-left: 4px solid #ff9a9e;
   border-radius: 6px;
 }
 
@@ -236,7 +244,7 @@ section {
     font-size: 30px;
     cursor: pointer;
     padding: 10px 0;
-    color: #2196f3;
+    color: #fff;
   }
 
   /* ナビゲーションリストを隠す・縦並びに */
@@ -293,40 +301,5 @@ section {
   /* セクションの余白を調整 */
   section {
     padding: 5px;
-  }
-}
-@media (max-width: 600px) {
-
-  /* ハンバーガーメニューを表示 */
-  .hamburger {
-    display: block;
-    font-size: 30px;
-    cursor: pointer;
-    padding: 10px 0;
-    color: #2196f3;
-  }
-
-  /* ナビゲーションリスト（ul）を最初は隠す */
-  .nav-list {
-    display: none;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-  }
-
-  /* ハンバーガー押して.activeが付いたら表示 */
-  .nav-list.active {
-    display: flex;
-  }
-
-  .nav-list > li {
-    width: 100%;
-    text-align: center;
-  }
-
-  .nav-list > li > a {
-    padding: 12px 0;
-    width: 100%;
-    border-bottom: 1px solid #eee;
   }
 }


### PR DESCRIPTION
## Summary
- refresh portfolio style with darker navigation
- use light gradient background and centered content
- update cards and section styling

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d10dace64832fbcf7c90783e7821e